### PR TITLE
Included logic for adding custom sanitizers

### DIFF
--- a/src/main/java/com/code_intelligence/jazzer/agent/AgentInstaller.java
+++ b/src/main/java/com/code_intelligence/jazzer/agent/AgentInstaller.java
@@ -16,21 +16,28 @@ package com.code_intelligence.jazzer.agent;
 
 import static com.code_intelligence.jazzer.agent.AgentUtils.extractBootstrapJar;
 
+import java.io.File;
+import java.io.IOException;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.jar.JarFile;
+import java.util.logging.Logger;
+
+import com.code_intelligence.jazzer.r8.R8Wrapper;
+
 import net.bytebuddy.agent.ByteBuddyAgent;
 
 public class AgentInstaller {
   private static final AtomicBoolean hasBeenInstalled = new AtomicBoolean();
-
+  private static final Logger logger = Logger.getLogger(AgentInstaller.class.getName());
   /**
    * Appends the parts of Jazzer that have to be visible to all classes, including those in the Java
    * standard library, to the bootstrap class loader path. Additionally, if enableAgent is true,
    * also enables the Jazzer agent that instruments classes for fuzzing.
    */
-  public static void install(boolean enableAgent) {
+  public static void install(boolean enableAgent, File customHooksJar) {
     // Only install the agent once.
     if (!hasBeenInstalled.compareAndSet(false, true)) {
       return;
@@ -38,6 +45,18 @@ public class AgentInstaller {
 
     Instrumentation instrumentation = ByteBuddyAgent.install();
     instrumentation.appendToBootstrapClassLoaderSearch(extractBootstrapJar());
+
+    if (customHooksJar != null) {
+      try {
+        instrumentation.appendToBootstrapClassLoaderSearch(new JarFile(customHooksJar));
+        logger.info("Added external hooks jar to bootstrap: " + customHooksJar.getAbsolutePath());
+      } catch (IOException e) {
+        logger.warning("Failed to add external hooks jar due to error: " + e);
+      }
+    } else {
+      logger.warning("Jar for adding custom hooks is not present to add in bootstrap class loader search.");
+    }
+
     if (!enableAgent) {
       return;
     }

--- a/src/main/java/com/code_intelligence/jazzer/android/BUILD.bazel
+++ b/src/main/java/com/code_intelligence/jazzer/android/BUILD.bazel
@@ -67,7 +67,6 @@ java_binary (
     name = "r8",
     resources = [
         ":jazzer_jar",
-        "jazzer_instrumentation_config.json",
     ],
     main_class = "com.code_intelligence.jazzer.r8.R8Wrapper",
     srcs = ["R8Wrapper.java"],

--- a/src/main/java/com/code_intelligence/jazzer/android/InstrumentationConfig.java
+++ b/src/main/java/com/code_intelligence/jazzer/android/InstrumentationConfig.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -35,6 +36,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.jar.JarFile;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -61,9 +63,12 @@ import java.util.stream.Collectors;
  *       "com.code_intelligence.jazzer.sanitizers.SqlInjection"
  *     ]
  *   },
- *   "custom_hooks": [
- *     "com.example.ExampleFuzzerHook"
- *   ]
+ *   "custom_hooks": {
+ *     "custom_hooks_classes": [
+ *       "com.code_intelligence.jazzer.hooks.ExampleFuzzerHooks"
+ *      ],
+ *     "custom_hooks_jar_path": "prebuilts/jazzer/libcustom_hooks.jar"
+ *   }
  * }
  *
  * Supplying this JSON configuration file is optional. If the file is not provided, all hooks
@@ -89,10 +94,18 @@ import java.util.stream.Collectors;
  * "enabled_hooks" is used, only the listed hooks will be enabled. Hooks must be written as
  * fully-qualified Java class names.
  *
- * ###3. `custom_hooks`
- * This array allows additional fully-qualified hook class names to be listed
- * outside the predefined set. Currently, this feature is not supported at runtime, but
- * support is planned for future versions.
+ * ### 3. `custom_hooks`
+ * This object allows users to define additional sanitizer hooks externally.
+ * It contains:
+ *   - `custom_hooks_classes`: an array of fully-qualified hook class names 
+ *      that should be activated during instrumentation and runtime.
+ *   - `custom_hooks_jar_path`: a path to the precompiled hooks JAR that contains 
+ *      these classes. This can be either an absolute path or a path relative to 
+ *      the current working directory. The JAR will be added to the bootstrap 
+ *      classpath to ensure proper visibility.
+ *
+ * Together, these fields enable integrating custom hooks without rebuilding 
+ * Jazzer itself. If omitted, no external hooks are loaded.
  */
 public class InstrumentationConfig {
 
@@ -101,6 +114,8 @@ public class InstrumentationConfig {
     private final String JAZZER_HOOKS = "jazzer_hooks";
     private final String INSTRUMENTATION_FILTERS = "instrumentation_filters";
     private final String CUSTOM_HOOKS = "custom_hooks";
+    private final String CUSTOM_HOOKS_CLASSES = "custom_hooks_classes";
+    private final String CUSTOM_HOOKS_JAR_PATH = "custom_hooks_jar_path";
     private final String INCLUDE_FILTER = "include_filter";
     private final String EXCLUDE_FILTER = "exclude_filter";
     private final String DISABLED_HOOKS = "disabled_hooks";
@@ -109,8 +124,11 @@ public class InstrumentationConfig {
     private final Map<String, Boolean> hookStates = new HashMap<>();
     private final List<String> includeFilter = new ArrayList<>();
     private final List<String> excludeFilter = new ArrayList<>();
+    private final List<String> customHooksClasses = new ArrayList<>();
     private final Path dumpClassesDir;
 
+    private File customHooksJar;
+    
     public InstrumentationConfig() {
         // Disable all the hooks by default
         for (String hook : Constants.SANITIZER_HOOK_NAMES) {
@@ -137,7 +155,9 @@ public class InstrumentationConfig {
                         parseInstrumentationFilter(json.getAsJsonObject(key));
                         break;
                     case CUSTOM_HOOKS:
-                        parseCustomHooks(json.getAsJsonArray(key));
+                        JsonObject hooksObj = json.getAsJsonObject(key);
+                        parseCustomHooksJarPath(hooksObj);
+                        parseCustomHooksClasses(hooksObj);
                         break;
                     default:
                         logger.warning("Unsupported top-level config entry: " + key);
@@ -160,7 +180,18 @@ public class InstrumentationConfig {
         addOptionIfNotEmpty(disabledHooks, "--disabled_hooks=", jazzerOpts);
         addOptionIfNotEmpty(includeFilter, "--instrumentation_includes=", jazzerOpts);
         addOptionIfNotEmpty(excludeFilter, "--instrumentation_excludes=", jazzerOpts);
+
+        if(customHooksJar != null){
+            addOptionIfNotEmpty(customHooksClasses, "--custom_hooks=", jazzerOpts);
+        }
         jazzerOpts.add("--dump_classes_dir=" + dumpClassesDir.toString());
+    }
+    
+    public File getCustomHooksJar() {
+        if(customHooksJar == null){
+            logger.warning("custom hooks jar has not provided.");
+        }
+        return customHooksJar;
     }
 
     private void parseJazzerHooks(JsonObject hooksObj) {
@@ -209,9 +240,34 @@ public class InstrumentationConfig {
         }
     }
 
-    private void parseCustomHooks(JsonArray hooksArray) {
-        // TODO: Add support for custom_hooks
-        logger.warning("custom_hooks option is not enabled yet.");
+    private void parseCustomHooksClasses(JsonObject hooksObj) {
+        if (hooksObj.has(CUSTOM_HOOKS_CLASSES)) {
+            JsonArray hooksArray = hooksObj.getAsJsonArray(CUSTOM_HOOKS_CLASSES);
+            for (JsonElement el : hooksArray) {
+                customHooksClasses.add(el.getAsString());
+            }
+        } else {
+            logger.warning("Expected 'custom_hooks_classes' entry not found in custom_hooks config.");
+        }
+    }
+
+    private void parseCustomHooksJarPath(JsonObject hooksObj) {
+        if (hooksObj.has(CUSTOM_HOOKS_JAR_PATH)) {
+            String customHooksJarPath = hooksObj.get(CUSTOM_HOOKS_JAR_PATH).getAsString();
+            if (customHooksJarPath != null && !customHooksJarPath.isBlank()) {
+                customHooksJar = new File(customHooksJarPath);
+                if (!customHooksJar.exists()) {
+                    logger.warning("Custom hooks jar not found at: " + customHooksJarPath 
+                        + ". Continuing without custom hooks.");
+                    customHooksJar = null;
+                    return;
+                }
+            } else {
+                logger.warning("No custom hooks jar path provided.");
+            }
+        } else {
+            logger.warning("Expected 'custom_hooks_jar_path' entry not found in custom_hooks config.");
+        }
     }
 
     private void addOptionIfNotEmpty(List<String> list, String flag, List<String> jazzerOpts) {

--- a/src/main/java/com/code_intelligence/jazzer/android/R8Wrapper.java
+++ b/src/main/java/com/code_intelligence/jazzer/android/R8Wrapper.java
@@ -23,6 +23,7 @@ import main.java.com.code_intelligence.jazzer.android.InstrumentationConfig;
 import com.code_intelligence.jazzer.driver.OfflineInstrumentor;
 import com.code_intelligence.jazzer.driver.Opt;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ClassNotFoundException;
@@ -38,18 +39,22 @@ import java.util.logging.Logger;
 public class R8Wrapper {
   private static final Logger logger = Logger.getLogger(R8Wrapper.class.getName());
 
+  // Path to the instrumentation config file on the host.
+  // It is relative to the current working directory.
+  private static final String CONFIG_FILE_PATH = "prebuilts/jazzer/jazzer_instrumentation_config.json";
+  private static File customHooksJar;
+
   private static void setOptions() throws Exception {
     List<String> jazzerOpts = new ArrayList<>();
     // default config object will have all the default hooks disabled
     InstrumentationConfig config = new InstrumentationConfig();
 
-    InputStream input = R8Wrapper.class
-        .getClassLoader()
-        .getResourceAsStream("com/code_intelligence/jazzer/android/jazzer_instrumentation_config.json");
+    File configFile = new File(CONFIG_FILE_PATH);
 
-    if (input != null) {
-      try (InputStream in = input) {
-        config.updateFromJson(in);
+    if (configFile.exists()) {
+      try (FileInputStream fis = new FileInputStream(configFile)) {
+        config.updateFromJson(fis);
+        customHooksJar = config.getCustomHooksJar();
       }
     } else {
       logger.info("No instrumentation config found — using default config.");
@@ -71,7 +76,7 @@ public class R8Wrapper {
 
       // found com.android.tools.r8warpper.R8Wrapper
       // don't add native libs, we are in AOSP and Soong has special code for this
-      boolean instrumentationSuccess = OfflineInstrumentor.instrumentJars(jarfiles, false);
+      boolean instrumentationSuccess = OfflineInstrumentor.instrumentJars(jarfiles, false, customHooksJar);
       if (!instrumentationSuccess) {
         exit(1);
       }

--- a/src/main/java/com/code_intelligence/jazzer/driver/OfflineInstrumentor.java
+++ b/src/main/java/com/code_intelligence/jazzer/driver/OfflineInstrumentor.java
@@ -49,9 +49,9 @@ import java.util.jar.Manifest;
 import java.util.zip.ZipOutputStream;
 
 public class OfflineInstrumentor {
-  public static boolean instrumentJars(List<String> jarList, boolean addNativeLibs)
+  public static boolean instrumentJars(List<String> jarList, boolean addNativeLibs, File customHooksJar)
       throws IOException {
-    AgentInstaller.install(true);
+    AgentInstaller.install(true, customHooksJar);
     // TODO: as a working proof of concept, this has only been tested on one jar.
     // This should be fine for most scenarios since this should be happening directly
     // before dexing.


### PR DESCRIPTION
Added support for integrating custom sanitizers via a prebuilt hooks JAR stored in AOSP. The JSON configuration file was also moved into the AOSP repository, decoupling it from the R8Wrapper logic and allowing configuration updates without rebuilding Jazzer.