### PR TITLE
Included Bazel binary for FuzzApkTool branch

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,21 @@
+# Bazel Binary for FuzzApkTool
+
+This directory contains a **prebuilt Bazel binary** required to build the `FuzzApkTool` branch of Jazzer.
+
+---
+
+## Why is this needed?
+
+The `FuzzApkTool` branch depends on a **specific Bazel version** that is not available through regular package managers.  
+Other Bazel versions fail to build due to incompatibilities with the `WORKSPACE` configuration and build rules.  
+
+To address this, we provide the **exact Bazel binary** known to work with this PoC.
+
+---
+
+## Usage
+
+To use this binary, specify "tools/bazel" during running any bazel build like:
+
+```bash
+tools/bazel build <target>


### PR DESCRIPTION
I have added a bazel binary to use for build process in FuzzApkTool branch as it needs this specific commit which is not present in public domain.